### PR TITLE
[Bugfix] Landing page grid widths have been fixed

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -9,7 +9,7 @@ class Header extends React.Component
     render()
     {
         return(
-            <div id="header" className="text-light pl-4 pr-4 d-flex flex-column justify-content-between align-items-start border h-100">
+            <div id="header" className="text-light pr-2 pl-2 d-flex flex-column justify-content-between align-items-start h-100">
                 <div>
                     <h5 className="m-0 p-3 font-weight-bold">Dentapp</h5>
                     <hr className="bg-light m-0" />
@@ -17,7 +17,7 @@ class Header extends React.Component
                         <Link to="/">
                             <li className="p-2 pl-3 pr-3">
                                 <i className="fas fa-users"></i>
-                                <span className="ml-3">User Profile</span>
+                                <span className="ml-3">User Management</span>
                             </li>
                         </Link>
                         <Link to="/appointments">
@@ -35,7 +35,7 @@ class Header extends React.Component
                         <Link to="treatment-management">
                             <li className="p-2 pl-3 pr-3">
                                 <i className="fas fa-pen-square"></i>
-                                <span className="ml-3">Treatment Mgmt.</span>
+                                <span className="ml-3">Treatment Management</span>
                             </li>
                         </Link>
                     </ul>

--- a/src/components/Pages/LandingPage.js
+++ b/src/components/Pages/LandingPage.js
@@ -9,11 +9,11 @@ class LandingPage extends React.Component
     {
         return(
             <Router history={ history }>
-                <div className="row m-0">
-                    <div className="col-2 p-0 bg-dark" style={{ height: '100vh' }}>
+                <div className="row m-0 flex-nowrap">
+                    <div className="flex-shrink-0 p-2 bg-dark" style={{ height: '100vh' }}>
                         <Header />
                     </div>
-                    <div className="col-10">
+                    <div className="flex-grow-1">
                         <Switch>
                             <Route path="/" exact component={ UserManagementPage } />
                         </Switch>


### PR DESCRIPTION
**Problem Description:**
Landing page content were not showing properly.

**Root Cause Analysis:**
Column widths were not set properly.

**Solution Description:**
I have set sidebar's flex-shrink property to false in order to prevent sıdebar is squeezed. Also set rest of the content's flex-grow property to true in order to fit on the screen. 